### PR TITLE
adição de parametro para exibir o erro completo não apenas o arquivo …

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,11 @@ class Router {
                 try {
                     require(path.resolve(x))
                 } catch (error) {
-                    console.error(x)
+                    if (process.env.SHOW_FULL_ERROR) {
+                        console.error(x, '\n', error)
+                    } else {
+                        console.error(x)
+                    }
                 }
             });
 


### PR DESCRIPTION
Checa á variável process.env.SHOW_FULL_ERROR que deve ser criada, caso esta variável possua  valor true,
ele não exibe apenas o arquivo que ocorreu o erro, mostra o arquivo e também o erro completo  